### PR TITLE
Empty clusters for means

### DIFF
--- a/init/kmeans.py
+++ b/init/kmeans.py
@@ -49,8 +49,12 @@ class Kmeans:
         for cluster in range(self.k):
             is_assigned_to_c = assigned[cluster]
             if not is_assigned_to_c.any():
-                continue
-            self.centroids[cluster, :] = x[is_assigned_to_c, :].mean(axis=0)
+                if x.size(0) > 0:
+                    self.centroids[cluster, :] = x[torch.randint(0, x.size(0), (1,))].squeeze(0)
+                else:
+                    raise ValueError("Can not choose random element from x, x is empty")
+            else:
+                self.centroids[cluster, :] = x[is_assigned_to_c, :].mean(axis=0)
         self.assignment = centroid_idx
 
     def run(self, x):


### PR DESCRIPTION
Hello! I found out that on some data kmeans init puts nans in centroids, so all subsequent steps will contain nans (even losses during training)
This is due to the thing that if is_assigned_to_c  (vectors in a cluster) is empty, then counting of mean() in self.centroids[cluster, :] = x[is_assigned_to_c, :].mean(axis=0) will cause nans, which will produce more nans

It is a corner case and not often, but I faced it on my data