### PR TITLE
deps: bump GitPython to 3.1.58 in requirements_macos.txt (GHSA-2f96-g7mh-g2hx)

### DIFF
--- a/requirements_macos.txt
+++ b/requirements_macos.txt
@@ -230,7 +230,7 @@ gcsfs==2024.9.0.post1
     # via -r requirements.in
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.44
+gitpython==3.1.58
     # via
     #   scmrepo
     #   wandb


### PR DESCRIPTION
Updates GitPython to address GHSA-2f96-g7mh-g2hx.

Evidence:
- `requirements_macos.txt` pinned `gitpython==3.1.44`
- osv-scanner reported GHSA-2f96-g7mh-g2hx (command injection via long-option prefix abbreviation bypass) plus 14 other GitPython advisories for 3.1.44
- updated version: 3.1.58, the line clear of every current GitPython advisory

Validation:
- osv-scanner no longer reports any GitPython advisory after the update
- pinned `gitdb==4.0.12` still satisfies the 3.1.58 requirement (`gitdb<5,>=4.0.1`)
- full local install of the pinned requirements file was not run (torch/tensorflow CUDA stack, macOS-targeted pin set); the maintainer `pytest` documented in CONTRIBUTING.md was not executed here

Scope: dependency pin update only (`requirements_macos.txt`, one line).
